### PR TITLE
fix(climate): update entity IDs to _mqtt_hvac suffix #24

### DIFF
--- a/automation/climate_bedroom_auto_off_at_night.yaml
+++ b/automation/climate_bedroom_auto_off_at_night.yaml
@@ -13,7 +13,7 @@ condition:
   - condition: template
     value_template: >
       {{
-        states('climate.bedroom') == 'cool'
+        states('climate.bedroom_mqtt_hvac') == 'cool'
         and states('binary_sensor.hisense_ac_bedroom_automation_block_status') == 'off'
         and (now().hour >= 23 or now().hour < 6)
       }}
@@ -26,7 +26,7 @@ actions:
   # Turn off the AC
   - action: climate.turn_off
     target:
-      entity_id: climate.bedroom
+      entity_id: climate.bedroom_mqtt_hvac
   # Log the action
   - action: system_log.write
     data:

--- a/automation/climate_bedroom_auto_off_on_target_temp.yaml
+++ b/automation/climate_bedroom_auto_off_on_target_temp.yaml
@@ -24,7 +24,7 @@ condition:
       {% set current_timestamp = now().timestamp() %}
       {% set ac_run_time = (current_timestamp - ac_start_timestamp) / 60 %}
       {{
-        states('climate.bedroom') == 'cool'
+        states('climate.bedroom_mqtt_hvac') == 'cool'
         and states('sensor.qingping_bedroom_temperature') | float <= 22
         and ac_run_time > 30
       }}
@@ -43,7 +43,7 @@ actions:
   # Turn off the AC
   - action: climate.turn_off
     target:
-      entity_id: climate.bedroom
+      entity_id: climate.bedroom_mqtt_hvac
   # Log the action
   - action: system_log.write
     data:

--- a/automation/climate_bedroom_auto_off_on_window_open.yaml
+++ b/automation/climate_bedroom_auto_off_on_window_open.yaml
@@ -22,7 +22,7 @@ condition:
     value_template: >
       {% set last_changed = states.binary_sensor.aqara_contact_window_bedroom_contact.last_changed %}
       {{
-        states('climate.bedroom') == 'on'
+        states('climate.bedroom_mqtt_hvac') == 'on'
         and states('binary_sensor.aqara_contact_window_bedroom_contact') == 'on'
         and last_changed is not none
         and (as_timestamp(now()) - as_timestamp(last_changed)) > 300
@@ -49,7 +49,7 @@ action:
 
           - service: climate.turn_off
             target:
-              entity_id: climate.bedroom
+              entity_id: climate.bedroom_mqtt_hvac
 
           - service: system_log.write
             data:

--- a/automation/climate_bedroom_auto_on.yaml
+++ b/automation/climate_bedroom_auto_on.yaml
@@ -1,4 +1,4 @@
-# i have a climate climate.bedroom. and an environment sensor sensor.qingping_bedroom_temperature
+# i have a climate climate.bedroom_mqtt_hvac. and an environment sensor sensor.qingping_bedroom_temperature
 # i have a window contact sensor to check whether the window is open or closed binary_sensor.aqara_contact_window_bedroom_contact, i have another sensor sensor.weather_forecast_temperature_forecast
 # create a home-assistant automation that:
 # turns on the ac when the temperature is above 24 degrees and the window is closed

--- a/automation/climate_bedroom_manual_control.yaml
+++ b/automation/climate_bedroom_manual_control.yaml
@@ -21,13 +21,13 @@ mode: restart
 triggers:
   # Manual switch turned on
   - platform: state
-    entity_id: climate.bedroom
+    entity_id: climate.bedroom_mqtt_hvac
     to: "on"
     id: manual_on
 
   # Manual switch turned off
   - platform: state
-    entity_id: climate.bedroom
+    entity_id: climate.bedroom_mqtt_hvac
     to: "off"
     id: manual_off
 

--- a/automation/climate_bedroom_track_start_time.yaml
+++ b/automation/climate_bedroom_track_start_time.yaml
@@ -6,7 +6,7 @@ description: >
 mode: single
 trigger:
   - platform: state
-    entity_id: climate.bedroom
+    entity_id: climate.bedroom_mqtt_hvac
     from: "off"
 condition:
   # Only run if changing to any active mode (not to "off" or "unknown")

--- a/automation/climate_livingroom_auto_off_at_night.yaml
+++ b/automation/climate_livingroom_auto_off_at_night.yaml
@@ -13,7 +13,7 @@ condition:
   - condition: template
     value_template: >
       {{
-        states('climate.livingroom') == 'cool'
+        states('climate.livingroom_mqtt_hvac') == 'cool'
         and states('binary_sensor.hisense_ac_livingroom_automation_block_status') == 'off'
         and (now().hour >= 23 or now().hour < 6)
       }}
@@ -26,7 +26,7 @@ actions:
   # Turn off the AC
   - action: climate.turn_off
     target:
-      entity_id: climate.livingroom
+      entity_id: climate.livingroom_mqtt_hvac
   # Log the action
   - action: system_log.write
     data:

--- a/automation/climate_livingroom_auto_off_on_target_temp.yaml
+++ b/automation/climate_livingroom_auto_off_on_target_temp.yaml
@@ -24,7 +24,7 @@ condition:
       {% set current_timestamp = now().timestamp() %}
       {% set ac_run_time = (current_timestamp - ac_start_timestamp) / 60 %}
       {{
-        states('climate.livingroom') == 'cool'
+        states('climate.livingroom_mqtt_hvac') == 'cool'
         and states('sensor.qingping_livingroom_temperature') | float <= 22
         and ac_run_time > 30
       }}
@@ -43,7 +43,7 @@ actions:
   # Turn off the AC
   - action: climate.turn_off
     target:
-      entity_id: climate.livingroom
+      entity_id: climate.livingroom_mqtt_hvac
   # Log the action
   - action: system_log.write
     data:

--- a/automation/climate_livingroom_auto_on.yaml
+++ b/automation/climate_livingroom_auto_on.yaml
@@ -1,4 +1,4 @@
-# i have a climate climate.livingroom. and an environment sensor sensor.qingping_livingroom_temperature
+# i have a climate climate.livingroom_mqtt_hvac. and an environment sensor sensor.qingping_livingroom_temperature
 # i have another sensor sensor.weather_forecast_temperature_forecast
 # create a home-assistant automation that:
 # turns on the ac when the temperature is above 24 degrees

--- a/automation/climate_livingroom_manual_control.yaml
+++ b/automation/climate_livingroom_manual_control.yaml
@@ -21,13 +21,13 @@ mode: restart
 triggers:
   # Manual switch turned on
   - platform: state
-    entity_id: climate.livingroom
+    entity_id: climate.livingroom_mqtt_hvac
     to: "on"
     id: manual_on
 
   # Manual switch turned off
   - platform: state
-    entity_id: climate.livingroom
+    entity_id: climate.livingroom_mqtt_hvac
     to: "off"
     id: manual_off
 

--- a/automation/climate_livingroom_track_start_time.yaml
+++ b/automation/climate_livingroom_track_start_time.yaml
@@ -6,7 +6,7 @@ description: >
 mode: single
 trigger:
   - platform: state
-    entity_id: climate.livingroom
+    entity_id: climate.livingroom_mqtt_hvac
     from: "off"
 condition:
   # Only run if changing to any active mode (not to "off" or "unknown")

--- a/scripts/cool_bedroom.yaml
+++ b/scripts/cool_bedroom.yaml
@@ -18,13 +18,13 @@ cool_bedroom:
         condition: template
         value_template: >
           {{
-            states('climate.bedroom') != 'cool'
+            states('climate.bedroom_mqtt_hvac') != 'cool'
           }}
       then:
         # set the AC to cooling mode
         - service: climate.set_hvac_mode
           target:
-            entity_id: climate.bedroom
+            entity_id: climate.bedroom_mqtt_hvac
           data:
             hvac_mode: cool
         # log the action
@@ -38,13 +38,13 @@ cool_bedroom:
         condition: template
         value_template: >
           {{
-            states('climate.bedroom') == 'off'
+            states('climate.bedroom_mqtt_hvac') == 'off'
           }}
       then:
         # turn on the AC
         - service: climate.turn_on
           target:
-            entity_id: climate.bedroom
+            entity_id: climate.bedroom_mqtt_hvac
         # log the action
         - service: system_log.write
           data:

--- a/scripts/cool_livingroom.yaml
+++ b/scripts/cool_livingroom.yaml
@@ -18,13 +18,13 @@ cool_livingroom:
         condition: template
         value_template: >
           {{
-            states('climate.livingroom') != 'cool'
+            states('climate.livingroom_mqtt_hvac') != 'cool'
           }}
       then:
         # set the AC to cooling mode
         - service: climate.set_hvac_mode
           target:
-            entity_id: climate.livingroom
+            entity_id: climate.livingroom_mqtt_hvac
           data:
             hvac_mode: cool
         # log the action
@@ -38,13 +38,13 @@ cool_livingroom:
         condition: template
         value_template: >
           {{
-            states('climate.livingroom') == 'off'
+            states('climate.livingroom_mqtt_hvac') == 'off'
           }}
       then:
         # turn on the AC
         - service: climate.turn_on
           target:
-            entity_id: climate.livingroom
+            entity_id: climate.livingroom_mqtt_hvac
         # log the action
         - service: system_log.write
           data:

--- a/templates/climate_bedroom_runtime.yaml
+++ b/templates/climate_bedroom_runtime.yaml
@@ -6,13 +6,13 @@ sensor:
     device_class: duration
     unit_of_measurement: min
     icon: >
-      {% if is_state('climate.bedroom', 'cool') %}
+      {% if is_state('climate.bedroom_mqtt_hvac', 'cool') %}
         mdi:timer-play-outline
       {% else %}
         mdi:timer-off-outline
       {% endif %}
     state: >
-      {% if is_state('climate.bedroom', 'cool') %}
+      {% if is_state('climate.bedroom_mqtt_hvac', 'cool') %}
         {{ (now().timestamp() - as_timestamp(states.input_datetime.climate_bedroom_start_time.state)) / 60 }}
       {% else %}
         0

--- a/templates/climate_livingroom_runtime.yaml
+++ b/templates/climate_livingroom_runtime.yaml
@@ -6,13 +6,13 @@ sensor:
     device_class: duration
     unit_of_measurement: min
     icon: >
-      {% if is_state('climate.livingroom', 'cool') %}
+      {% if is_state('climate.livingroom_mqtt_hvac', 'cool') %}
         mdi:timer-play-outline
       {% else %}
         mdi:timer-off-outline
       {% endif %}
     state: >
-      {% if is_state('climate.livingroom', 'cool') %}
+      {% if is_state('climate.livingroom_mqtt_hvac', 'cool') %}
         {{ (now().timestamp() - as_timestamp(states.input_datetime.climate_livingroom_start_time.state)) / 60 }}
       {% else %}
         0

--- a/ui-lovelace/00-test.yaml
+++ b/ui-lovelace/00-test.yaml
@@ -455,7 +455,7 @@ sections:
                         entity: sensor.qingping_livingroom_temperature
                         above: 24.9
                   - condition: state
-                    entity: climate.livingroom
+                    entity: climate.livingroom_mqtt_hvac
                     state_not: "off"
           - type: media-control
             entity: media_player.nvidia_shield

--- a/ui-lovelace/01-home.yaml
+++ b/ui-lovelace/01-home.yaml
@@ -261,7 +261,7 @@ sections:
           - effect
         name: Nanoloeaf Elements
       - type: custom:mushroom-climate-card
-        entity: climate.livingroom
+        entity: climate.livingroom_mqtt_hvac
         fill_container: false
         primary_info: name
         hvac_modes:
@@ -344,7 +344,7 @@ sections:
           - last_updated
         name: motion
       - type: custom:mushroom-climate-card
-        entity: climate.bedroom
+        entity: climate.bedroom_mqtt_hvac
         fill_container: false
         primary_info: name
         hvac_modes:

--- a/ui-lovelace/02-bedroom.yaml
+++ b/ui-lovelace/02-bedroom.yaml
@@ -48,7 +48,7 @@ sections:
         heading: Climate
         heading_style: title
       - type: custom:mushroom-climate-card
-        entity: climate.bedroom
+        entity: climate.bedroom_mqtt_hvac
         fill_container: true
         hvac_modes:
           - cool


### PR DESCRIPTION
## Summary

All climate automations were broken due to entity ID mismatch after MQTT HVAC migration.

## Change

Renamed all references from:
- `climate.livingroom` → `climate.livingroom_mqtt_hvac`
- `climate.bedroom` → `climate.bedroom_mqtt_hvac`

## Files Changed

- **2 scripts** (`cool_livingroom.yaml`, `cool_bedroom.yaml`)
- **9 automations** (track_start_time, manual_control, auto_on, auto_off_*)
- **2 templates** (climate runtime sensors)
- **3 UI lovelace** files (`01-home.yaml`, `02-bedroom.yaml`, `00-test.yaml`)

Relates to #24