### PR TITLE
fix(scene): use white light, spots 1-3 only for purple gaming #69

### DIFF
--- a/scenes/office_purple_gaming.yaml
+++ b/scenes/office_purple_gaming.yaml
@@ -7,10 +7,6 @@ entities:
     brightness: 40 # 16%
     color_temp: 300 # Balanced neutral (~ 3300K)
   light.tradfri_color_spot_02:
-    state: "on"
-    brightness: 40 # 16%
-    color_temp: 300 # Balanced neutral (~ 3300K)
+    state: "off"
   light.tradfri_color_spot_03:
-    state: "on"
-    brightness: 40 # 16%
-    color_temp: 300 # Balanced neutral (~ 3300K)
+    state: "off"

--- a/scenes/office_purple_gaming.yaml
+++ b/scenes/office_purple_gaming.yaml
@@ -4,21 +4,13 @@ icon: mdi:controller
 entities:
   light.tradfri_color_spot_01:
     state: "on"
-    brightness: 3 # 1%
-    rgb_color: [128, 0, 255]
+    brightness: 40 # 16%
+    color_temp: 300 # Balanced neutral (~ 3300K)
   light.tradfri_color_spot_02:
-    state: "off"
+    state: "on"
+    brightness: 40 # 16%
+    color_temp: 300 # Balanced neutral (~ 3300K)
   light.tradfri_color_spot_03:
-    state: "off"
-  light.tradfri_color_spot_04:
     state: "on"
-    brightness: 3 # 1%
-    rgb_color: [128, 0, 255]
-  light.tradfri_color_spot_05:
-    state: "on"
-    brightness: 3 # 1%
-    rgb_color: [128, 0, 255]
-  light.tradfri_color_spot_06:
-    state: "on"
-    brightness: 3 # 1%
-    rgb_color: [128, 0, 255]
+    brightness: 40 # 16%
+    color_temp: 300 # Balanced neutral (~ 3300K)

--- a/ui-lovelace/00-test.yaml
+++ b/ui-lovelace/00-test.yaml
@@ -117,10 +117,11 @@ sections:
           - type: horizontal-stack
             cards:
               - type: tile
-                entity: scene.office_reading
+                entity: scene.office_purple_gaming
                 color: deep-purple
                 hide_state: true
-                name: Reading
+                name: Purple Gaming
+                icon: mdi:controller
                 tap_action:
                   action: toggle
                 hold_action:

--- a/ui-lovelace/03-office.yaml
+++ b/ui-lovelace/03-office.yaml
@@ -85,16 +85,6 @@ sections:
           action: toggle
         hold_action:
           action: more-info
-      - type: tile
-        entity: scene.office_purple_gaming
-        name: Purple Gaming
-        color: deep-purple
-        hide_state: true
-        icon: mdi:controller
-        tap_action:
-          action: toggle
-        hold_action:
-          action: more-info
   - type: grid
     cards:
       - type: heading


### PR DESCRIPTION
- Changed purple gaming scene from `rgb_color` (purple) to `color_temp` (normal white) to fix lights staying purple when switching to other scenes
- Limited to spots 1-3 only (not whole room)
- Added scene tile to laboratory dashboard, removed from office dashboard

Refs #69