### PR TITLE
fix(scripts): red breath color temp kelvin support

### DIFF
--- a/scripts/office_light_red_breath.yaml
+++ b/scripts/office_light_red_breath.yaml
@@ -10,9 +10,8 @@ office_light_red_breath:
 
     # Store current state
     - variables:
-        # original_brightness: "{{ state_attr('light.office', 'brightness') }}"
-        original_rgb: "{{ state_attr('light.office', 'rgb_color') }}"
-        original_color_temp: "{{ state_attr('light.office', 'color_temp') }}"
+        original_brightness: "{{ state_attr('light.office', 'brightness') }}"
+        original_color_temp: "{{ state_attr('light.office', 'color_temp_kelvin') or 3200 }}"
 
     # Fade to red over 1.5 seconds
     - action: light.turn_on
@@ -27,37 +26,36 @@ office_light_red_breath:
     - delay:
         seconds: 3
 
-    # Fade back to original state over 1.5 seconds
+    # Fade back to original state over 2 seconds
     - action: light.turn_on
       target:
         entity_id: light.office
       data:
-        # brightness: "{{ original_brightness }}"
-        rgb_color: "{{ original_rgb if original_rgb else [255, 255, 255] }}"
+        brightness: "{{ original_brightness | int }}"
+        color_temp_kelvin: "{{ original_color_temp | int }}"
         transition: 2
 
     # Wait for fade to complete + hold red briefly
     - delay:
         seconds: 3
 
-    # Fade to red over 1.5 seconds
+    # Fade to red over 2 seconds
     - action: light.turn_on
       target:
         entity_id: light.office
       data:
         rgb_color: [255, 0, 0]
-        # brightness: 255
         transition: 2
 
     # Wait for fade to complete + hold red briefly
     - delay:
         seconds: 3
 
-    # Fade back to original state over 1.5 seconds
+    # Fade back to original state over 2 seconds
     - action: light.turn_on
       target:
         entity_id: light.office
       data:
-        # brightness: "{{ original_brightness }}"
-        rgb_color: "{{ original_rgb if original_rgb else [255, 255, 255] }}"
+        brightness: "{{ original_brightness | int }}"
+        color_temp_kelvin: "{{ original_color_temp | int }}"
         transition: 2


### PR DESCRIPTION
Replace `color_temp` (mired) with `color_temp_kelvin` and `rgb_color` with `brightness` + `color_temp_kelvin` in the red breath restore actions to match the light's native color mode.