### PR TITLE
chore(skills): add home-assistant-best-practices skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ tts/
 www/
 *recycle
 *.tar.gz
+
+# External agent skills (managed via skills-lock.json, install with: npx skills install)
+# To track a self-maintained skill, add: !.agents/skills/<skill-name>
+.agents/skills/

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "home-assistant-best-practices": {
+      "source": "homeassistant-ai/skills",
+      "sourceType": "github",
+      "skillPath": "skills/home-assistant-best-practices/SKILL.md",
+      "computedHash": "e694ed2c17dfd58242aa4036f0ad718e44a37e4b229a796d32f9098168ee7a25"
+    }
+  }
+}


### PR DESCRIPTION
Add the Home Assistant Best Practices skill from homeassistant-ai/skills, along with lint configuration exclusions for vendored skill files.