### PR TITLE
feat(livingroom): climate auto-off on window/door open + condition reorder #24

### DIFF
--- a/automation/climate_bedroom_auto_on.yaml
+++ b/automation/climate_bedroom_auto_on.yaml
@@ -28,14 +28,14 @@ condition:
     value_template: >
       {% set current_time = now() %}
       {{
-        current_time.strftime('%H:%M') >= '09:30'
-        and         current_time.strftime('%H:%M') < '22:00'
-        and states('sensor.qingping_bedroom_temperature') | float > 23
+        states('input_boolean.heating_season') == 'off'
         and states('binary_sensor.aqara_contact_window_bedroom_contact') == 'off'
+        and current_time.strftime('%H:%M') >= '09:30'
+        and current_time.strftime('%H:%M') < '22:00'
+        and states('sensor.qingping_bedroom_temperature') | float > 23
         and states('sensor.weather_forecast_temperature_forecast') | float > 25
         and states('sensor.hisense_ac_bedroom_lock_status') != 'locked'
         and states('binary_sensor.hisense_ac_bedroom_automation_block_status') == 'off'
-        and states('input_boolean.heating_season') == 'off'
       }}
 actions:
   - action: script.cool_bedroom

--- a/automation/climate_livingroom_auto_off_on_window_open.yaml
+++ b/automation/climate_livingroom_auto_off_on_window_open.yaml
@@ -1,0 +1,69 @@
+---
+alias: Climate Livingroom Auto Off on Window Open
+id: climate_livingroom_auto_off_on_window_open
+description: >
+  Automatically turns off the livingroom AC when a window or door is open for more than 5 minutes.
+  Monitors the livingroom window, garden door, and kitchen window.
+mode: single
+trigger:
+  - platform: time_pattern
+    minutes: "/5"
+  - platform: state
+    entity_id: binary_sensor.aqara_contact_window_livingroom_contact
+    to: "on"
+    for:
+      minutes: 5
+  - platform: state
+    entity_id: binary_sensor.aqara_contact_door_garden_contact
+    to: "on"
+    for:
+      minutes: 5
+  - platform: state
+    entity_id: binary_sensor.aqara_contact_window_kitchen_contact
+    to: "on"
+    for:
+      minutes: 5
+
+condition:
+  - condition: template
+    value_template: >
+      {% set window_lr = states.binary_sensor.aqara_contact_window_livingroom_contact %}
+      {% set door_garden = states.binary_sensor.aqara_contact_door_garden_contact %}
+      {% set window_kitchen = states.binary_sensor.aqara_contact_window_kitchen_contact %}
+      {{
+        states('climate.livingroom_mqtt_hvac') == 'cool'
+        and (
+          (window_lr.state == 'on' and window_lr.last_changed is not none and (as_timestamp(now()) - as_timestamp(window_lr.last_changed)) > 300)
+          or (door_garden.state == 'on' and door_garden.last_changed is not none and (as_timestamp(now()) - as_timestamp(door_garden.last_changed)) > 300)
+          or (window_kitchen.state == 'on' and window_kitchen.last_changed is not none and (as_timestamp(now()) - as_timestamp(window_kitchen.last_changed)) > 300)
+        )
+      }}
+
+action:
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: >
+              {% set window_lr = states.binary_sensor.aqara_contact_window_livingroom_contact %}
+              {% set door_garden = states.binary_sensor.aqara_contact_door_garden_contact %}
+              {% set window_kitchen = states.binary_sensor.aqara_contact_window_kitchen_contact %}
+              {{
+                (window_lr.state == 'on' and window_lr.last_changed is not none and (as_timestamp(now()) - as_timestamp(window_lr.last_changed)) > 300)
+                or (door_garden.state == 'on' and door_garden.last_changed is not none and (as_timestamp(now()) - as_timestamp(door_garden.last_changed)) > 300)
+                or (window_kitchen.state == 'on' and window_kitchen.last_changed is not none and (as_timestamp(now()) - as_timestamp(window_kitchen.last_changed)) > 300)
+              }}
+        sequence:
+          - service: rest_command.release_lock
+            data:
+              name: hisense_ac_livingroom
+
+          - service: climate.turn_off
+            target:
+              entity_id: climate.livingroom_mqtt_hvac
+
+          - service: system_log.write
+            data:
+              level: info
+              message: "Livingroom AC turned off due to open window/door for more than 5 minutes"
+              logger: homeassistant.components.automation.climate_livingroom_auto_off
+    default: []

--- a/automation/climate_livingroom_auto_on.yaml
+++ b/automation/climate_livingroom_auto_on.yaml
@@ -28,13 +28,16 @@ condition:
     value_template: >
       {% set current_time = now() %}
       {{
-        current_time.strftime('%H:%M') >= '09:30'
-        and         current_time.strftime('%H:%M') < '22:00'
+        states('input_boolean.heating_season') == 'off'
+        and states('binary_sensor.aqara_contact_window_livingroom_contact') == 'off'
+        and states('binary_sensor.aqara_contact_door_garden_contact') == 'off'
+        and states('binary_sensor.aqara_contact_window_kitchen_contact') == 'off'
+        and current_time.strftime('%H:%M') >= '09:30'
+        and current_time.strftime('%H:%M') < '22:00'
         and states('sensor.qingping_livingroom_temperature') | float > 23
         and states('sensor.weather_forecast_temperature_forecast') | float > 25
         and states('sensor.hisense_ac_livingroom_lock_status') != 'locked'
         and states('binary_sensor.hisense_ac_livingroom_automation_block_status') == 'off'
-        and states('input_boolean.heating_season') == 'off'
       }}
 actions:
   - action: script.cool_livingroom

--- a/automation/climate_livingroom_auto_on.yaml
+++ b/automation/climate_livingroom_auto_on.yaml
@@ -14,7 +14,7 @@
 # only handle on event in this automation, do not handle off events
 ---
 alias: Livingroom AC Auto On
-id: climatge_livingroom_auto_on
+id: climate_livingroom_auto_on
 description: >
   Automatically turns on the livingroom AC when the temperature is above 23°C,
   and the weather forecast temperature is above 25°C.

--- a/automation/climate_office_auto_on.yaml
+++ b/automation/climate_office_auto_on.yaml
@@ -14,14 +14,14 @@ condition:
     value_template: >
       {% set current_time = now() %}
       {{
-        current_time.strftime('%H:%M') >= '09:30'
-        and         current_time.strftime('%H:%M') < '22:00'
-        and states('sensor.qingping_office_temperature') | float > 23
+        states('input_boolean.heating_season') == 'off'
         and states('binary_sensor.aqara_contact_window_office_contact') == 'off'
+        and current_time.strftime('%H:%M') >= '09:30'
+        and current_time.strftime('%H:%M') < '22:00'
+        and states('sensor.qingping_office_temperature') | float > 23
         and states('sensor.weather_forecast_temperature_forecast') | float > 25
         and states('sensor.hisense_ac_office_lock_status') != 'locked'
         and states('binary_sensor.hisense_ac_office_automation_block_status') == 'off'
-        and states('input_boolean.heating_season') == 'off'
       }}
 actions:
   - action: script.cool_office


### PR DESCRIPTION
## Changes

### New automation
- `climate_livingroom_auto_off_on_window_open` — turns off livingroom AC when livingroom window, garden door, or kitchen window remains open for >5 minutes

### Auto-on updates
- **Livingroom**: added window/door closed checks (livingroom window, garden door, kitchen window)
- **All rooms**: reordered conditions so `heating_season` and window/door checks short-circuit before time, temperature, and forecast evaluations
- Fixed excessive spacing in auto-on condition templates