### PR TITLE
fix(open-meteo): apply max filter before temperature comparison

### DIFF
--- a/sensors/open_meteo_today_max_temperature.yaml
+++ b/sensors/open_meteo_today_max_temperature.yaml
@@ -26,7 +26,7 @@ json_attributes:
   - time
 icon: >
   {% if value_json is defined %}
-    {% if value_json.daily.temperature_2m_max > 28 %}
+    {% if value_json.daily.temperature_2m_max | max > 28 %}
       mdi:sun-thermometer
     {% else %}
       mdi:thermometer


### PR DESCRIPTION
Fix icon template error: `temperature_2m_max` is a list, so comparing it directly with `> 28` fails with `TypeError: '>' not supported between instances of 'list' and 'int'`. Apply the `| max` filter before comparison, matching the pattern already used in the `value_template`.