### PR TITLE
fix(automation): laundryroom in the dark mode

### DIFF
--- a/automation/laundryroom_light.yaml
+++ b/automation/laundryroom_light.yaml
@@ -2,7 +2,7 @@
 alias: laundryroom_light
 id: laundryroom_light
 description: Laundryroom light motion automation
-mode: single
+mode: restart
 triggers:
   - trigger: state
     entity_id:


### PR DESCRIPTION
Change the laundry room motion light automation mode from `single` to `restart`, so re-triggers during the timeout window properly reset the timer and the light stays on as long as motion is detected.

Without `restart`, the first motion event starts the timer and subsequent motion events while the light is on are ignored, which can leave the light turning off while someone is still in the room.