### PR TITLE
feat(mode): block light automation in office mode

### DIFF
--- a/automation/auto_block_control.yaml
+++ b/automation/auto_block_control.yaml
@@ -1,0 +1,126 @@
+---
+alias: Auto Block Control
+id: auto_block_control
+description: Manage the office light auto-block lock lifecycle with a manual countdown timer
+mode: restart
+triggers:
+  - trigger: state
+    entity_id: input_boolean.auto_block
+    id: auto_block_toggle
+  - trigger: homeassistant
+    event: start
+    id: ha_start
+  - trigger: event
+    event_type: timer.finished
+    event_data:
+      entity_id: timer.auto_block
+    id: timer_finished
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: timer_finished
+        sequence:
+          - service: rest_command.release_lock
+            data:
+              name: office_light
+          - service: input_boolean.turn_off
+            target:
+              entity_id: input_boolean.auto_block
+
+      - conditions:
+          - condition: state
+            entity_id: input_boolean.auto_block
+            state: "on"
+        sequence:
+          - service: rest_command.release_lock
+            data:
+              name: office_light
+          - choose:
+              - conditions:
+                  - condition: state
+                    entity_id: input_select.auto_block_duration
+                    state: "15 min"
+                sequence:
+                  - service: rest_command.create_lock
+                    data:
+                      name: office_light
+                      owner: homeassistant-auto-block
+                      duration: 15m
+                  - service: timer.start
+                    data:
+                      duration: "00:15:00"
+                    target:
+                      entity_id: timer.auto_block
+              - conditions:
+                  - condition: state
+                    entity_id: input_select.auto_block_duration
+                    state: "30 min"
+                sequence:
+                  - service: rest_command.create_lock
+                    data:
+                      name: office_light
+                      owner: homeassistant-auto-block
+                      duration: 30m
+                  - service: timer.start
+                    data:
+                      duration: "00:30:00"
+                    target:
+                      entity_id: timer.auto_block
+              - conditions:
+                  - condition: state
+                    entity_id: input_select.auto_block_duration
+                    state: "45 min"
+                sequence:
+                  - service: rest_command.create_lock
+                    data:
+                      name: office_light
+                      owner: homeassistant-auto-block
+                      duration: 45m
+                  - service: timer.start
+                    data:
+                      duration: "00:45:00"
+                    target:
+                      entity_id: timer.auto_block
+              - conditions:
+                  - condition: state
+                    entity_id: input_select.auto_block_duration
+                    state: "1 hour"
+                sequence:
+                  - service: rest_command.create_lock
+                    data:
+                      name: office_light
+                      owner: homeassistant-auto-block
+                      duration: 1h
+                  - service: timer.start
+                    data:
+                      duration: "01:00:00"
+                    target:
+                      entity_id: timer.auto_block
+              - conditions:
+                  - condition: state
+                    entity_id: input_select.auto_block_duration
+                    state: "2 hours"
+                sequence:
+                  - service: rest_command.create_lock
+                    data:
+                      name: office_light
+                      owner: homeassistant-auto-block
+                      duration: 2h
+                  - service: timer.start
+                    data:
+                      duration: "02:00:00"
+                    target:
+                      entity_id: timer.auto_block
+
+      - conditions:
+          - condition: state
+            entity_id: input_boolean.auto_block
+            state: "off"
+        sequence:
+          - service: rest_command.release_lock
+            data:
+              name: office_light
+          - service: timer.cancel
+            target:
+              entity_id: timer.auto_block

--- a/automation/auto_block_control.yaml
+++ b/automation/auto_block_control.yaml
@@ -35,82 +35,23 @@ actions:
             entity_id: input_boolean.auto_block
             state: "on"
         sequence:
-          - choose:
-              - conditions:
-                  - condition: state
-                    entity_id: input_select.auto_block_duration
-                    state: "15 min"
-                sequence:
-                  - service: rest_command.create_lock
-                    data:
-                      name: office_light
-                      owner: homeassistant-auto-block
-                      duration: 15m
-                  - service: timer.start
-                    data:
-                      duration: "00:15:00"
-                    target:
-                      entity_id: timer.auto_block
-              - conditions:
-                  - condition: state
-                    entity_id: input_select.auto_block_duration
-                    state: "30 min"
-                sequence:
-                  - service: rest_command.create_lock
-                    data:
-                      name: office_light
-                      owner: homeassistant-auto-block
-                      duration: 30m
-                  - service: timer.start
-                    data:
-                      duration: "00:30:00"
-                    target:
-                      entity_id: timer.auto_block
-              - conditions:
-                  - condition: state
-                    entity_id: input_select.auto_block_duration
-                    state: "45 min"
-                sequence:
-                  - service: rest_command.create_lock
-                    data:
-                      name: office_light
-                      owner: homeassistant-auto-block
-                      duration: 45m
-                  - service: timer.start
-                    data:
-                      duration: "00:45:00"
-                    target:
-                      entity_id: timer.auto_block
-              - conditions:
-                  - condition: state
-                    entity_id: input_select.auto_block_duration
-                    state: "1 hour"
-                sequence:
-                  - service: rest_command.create_lock
-                    data:
-                      name: office_light
-                      owner: homeassistant-auto-block
-                      duration: 1h
-                  - service: timer.start
-                    data:
-                      duration: "01:00:00"
-                    target:
-                      entity_id: timer.auto_block
-              - conditions:
-                  - condition: state
-                    entity_id: input_select.auto_block_duration
-                    state: "2 hours"
-                sequence:
-                  - service: rest_command.create_lock
-                    data:
-                      name: office_light
-                      owner: homeassistant-auto-block
-                      duration: 2h
-                  - service: timer.start
-                    data:
-                      duration: "02:00:00"
-                    target:
-                      entity_id: timer.auto_block
+          - variables:
+              minutes: >
+                {% set m = {"15 min": 15, "30 min": 30, "45 min": 45,
+                             "1 hour": 60, "2 hours": 120} %}
+                {{ m.get(states('input_select.auto_block_duration'), 60) }}
+          - service: rest_command.create_lock
+            data:
+              name: office_light
+              owner: homeassistant-auto-block
+              duration: >
+                {{ (minutes // 60 ~ 'h') if minutes % 60 == 0 and minutes >= 60
+                   else (minutes ~ 'm') }}
+          - service: timer.start
+            data:
+              duration: "{{ '%02d:%02d:00' | format(minutes // 60, minutes % 60) }}"
+            target:
+              entity_id: timer.auto_block
 
       - conditions:
           - condition: state

--- a/automation/auto_block_control.yaml
+++ b/automation/auto_block_control.yaml
@@ -7,9 +7,6 @@ triggers:
   - trigger: state
     entity_id: input_boolean.auto_block
     id: auto_block_toggle
-  - trigger: homeassistant
-    event: start
-    id: ha_start
   - trigger: event
     event_type: timer.finished
     event_data:

--- a/automation/auto_block_control.yaml
+++ b/automation/auto_block_control.yaml
@@ -72,3 +72,4 @@ actions:
           - service: timer.cancel
             target:
               entity_id: timer.auto_block
+      - default: []

--- a/automation/auto_block_control.yaml
+++ b/automation/auto_block_control.yaml
@@ -116,6 +116,9 @@ actions:
           - condition: state
             entity_id: input_boolean.auto_block
             state: "off"
+          - condition: state
+            entity_id: timer.auto_block
+            state: "active"
         sequence:
           - if:
               - condition: template

--- a/automation/auto_block_control.yaml
+++ b/automation/auto_block_control.yaml
@@ -21,9 +21,14 @@ actions:
           - condition: trigger
             id: timer_finished
         sequence:
-          - service: rest_command.release_lock
-            data:
-              name: office_light
+          - if:
+              - condition: template
+                value_template: >-
+                  {{ state_attr('sensor.office_light_lock_status', 'owner') == 'homeassistant-auto-block' }}
+            then:
+              - service: rest_command.release_lock
+                data:
+                  name: office_light
           - service: input_boolean.turn_off
             target:
               entity_id: input_boolean.auto_block
@@ -33,9 +38,6 @@ actions:
             entity_id: input_boolean.auto_block
             state: "on"
         sequence:
-          - service: rest_command.release_lock
-            data:
-              name: office_light
           - choose:
               - conditions:
                   - condition: state
@@ -118,9 +120,14 @@ actions:
             entity_id: input_boolean.auto_block
             state: "off"
         sequence:
-          - service: rest_command.release_lock
-            data:
-              name: office_light
+          - if:
+              - condition: template
+                value_template: >-
+                  {{ state_attr('sensor.office_light_lock_status', 'owner') == 'homeassistant-auto-block' }}
+            then:
+              - service: rest_command.release_lock
+                data:
+                  name: office_light
           - service: timer.cancel
             target:
               entity_id: timer.auto_block

--- a/docs/superpowers/plans/2026-07-28-climate-cooling-script.md
+++ b/docs/superpowers/plans/2026-07-28-climate-cooling-script.md
@@ -1,0 +1,207 @@
+# Climate Cooling Script Consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate 3 nearly-identical `cool_<zone>` scripts into a single parameterized `cool_room` script.
+
+**Architecture:** One script with a `zone` field (select: bedroom/livingroom/office) that maps to entity IDs via template variables, replacing the 3 per-zone copies. The 3 calling automations update their action target.
+
+**Tech Stack:** Home Assistant YAML script configuration, `fields:` for parameters, Jinja2 templates for entity resolution.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-climate-cooling-script-design.md`
+
+---
+
+### Task 1: Create consolidated `cool_room` script
+
+**Files:**
+- Create: `scripts/cool_room.yaml`
+
+- [ ] **Create the file**
+
+```yaml
+---
+cool_room:
+  alias: Cool Room
+  mode: single
+  fields:
+    zone:
+      required: true
+      selector:
+        select:
+          options:
+            - bedroom
+            - livingroom
+            - office
+    reason:
+      selector:
+        text:
+  sequence:
+    - variables:
+        lock_name: "hisense_ac_{{ zone }}"
+        ac_entity: "climate.{{ zone }}"
+    - service: rest_command.release_lock
+      data:
+        name: "{{ lock_name }}"
+    - service: rest_command.create_lock
+      data:
+        name: "{{ lock_name }}"
+        owner: homeassistant-automation
+        duration: 20m
+    - if:
+        - condition: template
+          value_template: "{{ states(ac_entity) != 'cool' }}"
+      then:
+        - service: climate.set_hvac_mode
+          target:
+            entity_id: "{{ ac_entity }}"
+          data:
+            hvac_mode: cool
+        - service: system_log.write
+          data:
+            level: info
+            message: "Set {{ zone }} AC mode: cooling."
+            logger: homeassistant.components.script.cool_room
+    - if:
+        - condition: template
+          value_template: "{{ states(ac_entity) == 'off' }}"
+      then:
+        - service: climate.turn_on
+          target:
+            entity_id: "{{ ac_entity }}"
+        - service: system_log.write
+          data:
+            level: info
+            message: "Started {{ zone }} AC: {{ reason | default('Manual') }}."
+            logger: homeassistant.components.script.cool_room
+```
+
+- [ ] **Commit**
+
+```bash
+git add scripts/cool_room.yaml
+git commit -m "feat(script): add consolidated cool_room script with zone parameter"
+```
+
+---
+
+### Task 2: Update `climate_bedroom_auto_on.yaml`
+
+**Files:**
+- Modify: `automation/climate_bedroom_auto_on.yaml`
+
+- [ ] **Change the action target**
+
+Replace line 41:
+```yaml
+  - action: script.cool_bedroom
+```
+with:
+```yaml
+  - action: script.cool_room
+    data:
+      zone: bedroom
+      reason: hot day and bedroom temperature to high
+```
+
+- [ ] **Commit**
+
+```bash
+git add automation/climate_bedroom_auto_on.yaml
+git commit -m "fix(automation): use cool_room script for bedroom AC"
+```
+
+---
+
+### Task 3: Update `climate_livingroom_auto_on.yaml`
+
+**Files:**
+- Modify: `automation/climate_livingroom_auto_on.yaml`
+
+- [ ] **Change the action target**
+
+Replace line 43:
+```yaml
+  - action: script.cool_livingroom
+```
+with:
+```yaml
+  - action: script.cool_room
+    data:
+      zone: livingroom
+      reason: hot day and livingroom temperature to high
+```
+
+- [ ] **Commit**
+
+```bash
+git add automation/climate_livingroom_auto_on.yaml
+git commit -m "fix(automation): use cool_room script for livingroom AC"
+```
+
+---
+
+### Task 4: Update `climate_office_auto_on.yaml`
+
+**Files:**
+- Modify: `automation/climate_office_auto_on.yaml`
+
+- [ ] **Change the action target**
+
+Replace line 27:
+```yaml
+  - action: script.cool_office
+```
+with:
+```yaml
+  - action: script.cool_room
+    data:
+      zone: office
+      reason: hot day and office temperature to high
+```
+
+- [ ] **Commit**
+
+```bash
+git add automation/climate_office_auto_on.yaml
+git commit -m "fix(automation): use cool_room script for office AC"
+```
+
+---
+
+### Task 5: Remove old per-zone scripts
+
+**Files:**
+- Delete: `scripts/cool_bedroom.yaml`
+- Delete: `scripts/cool_livingroom.yaml`
+- Delete: `scripts/cool_office.yaml`
+
+- [ ] **Delete the files**
+
+```bash
+git rm scripts/cool_bedroom.yaml scripts/cool_livingroom.yaml scripts/cool_office.yaml
+```
+
+- [ ] **Commit**
+
+```bash
+git commit -m "refactor(script): remove per-zone cool scripts, replaced by consolidated cool_room"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Check git status**
+
+```bash
+git status
+```
+Expected: clean working tree on `feature/climate-cooling-script`.
+
+- [ ] **Show final diff**
+
+```bash
+git diff main --stat
+```
+Expected: 1 new file, 3 modified, 3 deleted, ~150 lines net reduction.

--- a/docs/superpowers/specs/2026-07-28-climate-cooling-script-design.md
+++ b/docs/superpowers/specs/2026-07-28-climate-cooling-script-design.md
@@ -1,0 +1,119 @@
+# Climate Cooling Script Consolidation
+
+**Date:** 2026-07-28
+**Status:** Approved
+**Branch:** feature/climate-cooling-script
+
+## Goal
+
+Consolidate 3 nearly-identical `cool_<zone>` scripts (bedroom, livingroom, office) into a single parameterized script to eliminate duplication and simplify maintenance.
+
+## Current State
+
+Three scripts at `scripts/cool_bedroom.yaml`, `scripts/cool_livingroom.yaml`, `scripts/cool_office.yaml` — each 52 lines, 95% identical. Only differences are entity names (e.g., `climate.bedroom` vs `climate.livingroom`, lock names `hisense_ac_bedroom` vs `hisense_ac_livingroom`).
+
+Each script does:
+1. Release existing lock via REST API
+2. Create 20-minute automation lock via REST API
+3. If AC not in cooling mode → set HVAC mode to cool
+4. If AC is off → turn it on
+5. Log to system_log
+
+## Design
+
+### New file: `scripts/cool_room.yaml`
+
+A single parameterized script with a `zone` selector field:
+
+```yaml
+cool_room:
+  alias: Cool Room
+  mode: single
+  fields:
+    zone:
+      required: true
+      selector:
+        select:
+          options:
+            - bedroom
+            - livingroom
+            - office
+    reason:
+      selector:
+        text:
+  sequence:
+    - variables:
+        lock_name: "hisense_ac_{{ zone }}"
+        ac_entity: "climate.{{ zone }}"
+    - service: rest_command.release_lock
+      data:
+        name: "{{ lock_name }}"
+    - service: rest_command.create_lock
+      data:
+        name: "{{ lock_name }}"
+        owner: homeassistant-automation
+        duration: 20m
+    - if:
+        - condition: template
+          value_template: "{{ states(ac_entity) != 'cool' }}"
+      then:
+        - service: climate.set_hvac_mode
+          target:
+            entity_id: "{{ ac_entity }}"
+          data:
+            hvac_mode: cool
+        - service: system_log.write
+          data:
+            level: info
+            message: "Set {{ zone }} AC mode: cooling."
+            logger: homeassistant.components.script.cool_room
+    - if:
+        - condition: template
+          value_template: "{{ states(ac_entity) == 'off' }}"
+      then:
+        - service: climate.turn_on
+          target:
+            entity_id: "{{ ac_entity }}"
+        - service: system_log.write
+          data:
+            level: info
+            message: "Started {{ zone }} AC: {{ reason | default('Manual') }}."
+            logger: homeassistant.components.script.cool_room
+```
+
+### Updated files
+
+Three `climate_*_auto_on.yaml` automations — change the action target:
+
+| File | Old action | New action |
+|---|---|---|
+| `climate_bedroom_auto_on.yaml` | `script.cool_bedroom` | `script.cool_room { zone: "bedroom" }` |
+| `climate_livingroom_auto_on.yaml` | `script.cool_livingroom` | `script.cool_room { zone: "livingroom" }` |
+| `climate_office_auto_on.yaml` | `script.cool_office` | `script.cool_room { zone: "office" }` |
+
+### Deleted files
+
+- `scripts/cool_bedroom.yaml`
+- `scripts/cool_livingroom.yaml`
+- `scripts/cool_office.yaml`
+
+### Entity naming convention
+
+The template mapping relies on the consistent naming pattern across all zones:
+- Climate entity: `climate.<zone>` (e.g., `climate.bedroom`)
+- Lock name: `hisense_ac_<zone>` (e.g., `hisense_ac_bedroom`)
+
+This holds true for all 3 current zones (bedroom, livingroom, office).
+
+### What does NOT change
+
+- The `climate_*_auto_on.yaml` triggers and conditions remain untouched
+- No sensor, helper, input_datetime, or lock service changes
+- No automation behavior changes — strictly a refactor
+
+## Migration
+
+1. Create `scripts/cool_room.yaml`
+2. Update 3x `climate_*_auto_on.yaml` to call new script
+3. Delete 3x old `cool_<zone>.yaml` scripts
+4. Validate with `ha core check`

--- a/docs/superpowers/specs/2026-07-28-lock-collision-c1-design.md
+++ b/docs/superpowers/specs/2026-07-28-lock-collision-c1-design.md
@@ -1,0 +1,368 @@
+# Lock Collision Bug (C1) — Auto Block Control vs Manual Override
+
+**Date:** 2026-07-28
+**Status:** Draft — awaiting review
+**Related PR:** #150 (`automation/auto_block_control.yaml`)
+
+## Problem Summary
+
+`automation/auto_block_control.yaml` (PR #150) has two branches — `timer_finished` and the `off` branch — that call `rest_command.release_lock` **unconditionally**. During the auto-block period, `office_light_manual_control.yaml` can replace the lock owner from `homeassistant-auto-block` to `homeassistant-<user_id>`. When the timer expires or auto-block is turned off, the unconditional `release_lock` wipes the user's manual override lock prematurely.
+
+A third unconditional `release_lock` in the `on` branch (pre-create) and the `ha_start` trigger compound the problem: every HA restart with `input_boolean.auto_block` off wipes **any** existing lock (manual, gaming, etc.), not just auto-block locks.
+
+## System Architecture
+
+### Locking Service
+
+External REST service at `http://locking-service:3000`:
+
+| Endpoint | Method | Behavior |
+|---|---|---|
+| `/locks` | POST | Create/replace lock. Body: `{key, owner, duration}`. Only **one lock per key** exists at a time — POST replaces. |
+| `/locks/{name}` | DELETE | Release/delete a lock. Unconditional — no owner check server-side. |
+| `/locks/{name}` | GET | Return lock state (or empty body if unlocked). |
+
+### HA REST Commands
+
+- `rest_command.create_lock` → POST `/locks` with `{key: name, owner, duration}`
+- `rest_command.release_lock` → DELETE `/locks/{name}`
+
+### Sensor Layer
+
+- `sensor.office_light_lock_status` — REST sensor polling `GET /locks/office_light` every **15 seconds**. Reports `locked`/`unlocked`/`unknown` with attributes `owner`, `expireAt`, `createdAt`, `duration`, `key`.
+- `binary_sensor.office_light_automation_block_status` — template binary sensor. `on` when lock is `locked` AND owner != `homeassistant-automation`. This blocks the main light automation.
+
+### Lock Owners
+
+| Owner | Created by | Duration | Purpose |
+|---|---|---|---|
+| `homeassistant-<user_id>` | `office_light_manual_control.yaml` | 1h | Manual scene/light change |
+| `homeassistant-gaming-purple` | `office_light_gaming_mode_purple.yaml` | 4h | Gaming mode |
+| `homeassistant-auto-block` | `auto_block_control.yaml` (NEW) | variable (15m–2h) | UI toggle block |
+| `homeassistant-automation` | Various scripts (`cool_room`, etc.) | 20m | Automation's own lock (NOT blocked) |
+
+All owners except `homeassistant-automation` block the main light automation.
+
+### Auto Block Control Automation
+
+`auto_block_control.yaml`, `mode: restart`. Three triggers:
+
+1. `auto_block_toggle` — state change of `input_boolean.auto_block`
+2. `ha_start` — HA restart
+3. `timer_finished` — `timer.auto_block` finishes
+
+Three action branches (choose):
+
+| Branch | Condition | Actions |
+|---|---|---|
+| `timer_finished` | trigger id == timer_finished | `release_lock` (unconditional), `input_boolean.turn_off` |
+| `on` | `input_boolean.auto_block` == on | `release_lock` (unconditional), then `create_lock` (auto-block owner) + `timer.start` |
+| `off` | `input_boolean.auto_block` == off | `release_lock` (unconditional), `timer.cancel` |
+
+**Critical detail:** the `timer_finished` branch turns off `input_boolean.auto_block` (line 27-29), which re-triggers the `auto_block_toggle` trigger, firing the `off` branch. This causes a **double release** — the lock is deleted, then the `off` branch tries to delete it again (no-op or 404 error).
+
+### Existing Owner-Check Pattern
+
+`office_light_gaming_mode_purple_auto_off.yaml` already uses an owner check before releasing:
+
+```yaml
+conditions:
+  - condition: template
+    value_template: "{{ state_attr('sensor.office_light_lock_status', 'owner') == 'homeassistant-gaming-purple' }}"
+```
+
+This is the established pattern in this codebase for safe lock release.
+
+---
+
+## Scenario Analysis
+
+### Scenario A — Normal auto-block, no manual intervention
+
+**Flow:** User turns on auto-block → timer runs → timer expires.
+
+**Current (no owner check):**
+1. Auto-block on → `on` branch: release (no-op or wipes prior lock), create lock `homeassistant-auto-block`, start timer.
+2. Timer expires → `timer_finished` branch: release lock. Lock deleted. `input_boolean.auto_block` turned off.
+3. Turning off input_boolean re-triggers `off` branch: release again (no-op, lock already gone). Cancel timer (already finished).
+- **Result:** Lock released, auto-block off. **Correct.**
+
+**With owner check:**
+1. Same as above.
+2. Timer expires → `timer_finished` branch: owner == `homeassistant-auto-block`? Yes → release. Lock deleted. Turn off input_boolean.
+3. Re-trigger `off` branch: owner check — sensor may still show `homeassistant-auto-block` (15s lag) or `unlocked` (owner None). If stale: passes check, tries DELETE on already-deleted lock (404, harmless with `continue_on-error`). If fresh: fails check, skips release.
+- **Result:** Lock released, auto-block off. **Correct.** Minor: possible redundant DELETE that 404s.
+
+### Scenario B — Manual change during auto-block, then timer expires
+
+**Flow:** Auto-block on → user manually changes light → timer expires.
+
+**Current (no owner check):**
+1. Auto-block on → lock owner = `homeassistant-auto-block`, timer running.
+2. User manually changes light → `office_light_manual_control.yaml` fires: release lock, create lock `homeassistant-<user_id>` (1h). **Owner is now `homeassistant-<user_id>`.** Timer is still running. `input_boolean.auto_block` is still on.
+3. Timer expires → `timer_finished` branch: **unconditional release** wipes the user's manual lock. The 1h manual override is gone after only a fraction of its intended duration.
+4. `input_boolean.auto_block` turned off → `off` branch: release again (no-op).
+- **Result:** User's manual override destroyed. **BUG (C1).**
+
+**With owner check:**
+1-2. Same as above. Owner = `homeassistant-<user_id>`.
+3. Timer expires → `timer_finished` branch: owner == `homeassistant-auto-block`? **No** (it's `homeassistant-<user_id>`) → **skip release**. User's manual lock survives. Turn off `input_boolean.auto_block`.
+4. Re-trigger `off` branch: owner == `homeassistant-auto-block`? No → skip release. Cancel timer.
+- **Result:** User's manual override preserved. Auto-block UI shows off (period ended). **Correct.** The manual lock expires naturally at its own 1h deadline.
+
+### Scenario C — Manual change during auto-block, then user turns off auto-block
+
+**Flow:** Auto-block on → user manually changes light → user turns off auto-block.
+
+**Current (no owner check):**
+1. Auto-block on → lock owner = `homeassistant-auto-block`, timer running.
+2. User manually changes light → owner = `homeassistant-<user_id>`, 1h.
+3. User turns off auto-block → `off` branch: **unconditional release** wipes user's manual lock. Cancel timer.
+- **Result:** User's manual override destroyed. **BUG (C1).**
+
+**With owner check:**
+1-2. Same. Owner = `homeassistant-<user_id>`.
+3. User turns off auto-block → `off` branch: owner == `homeassistant-auto-block`? **No** → **skip release**. Cancel timer.
+- **Result:** User's manual override preserved. Auto-block is off. **Correct.**
+
+### Scenario D — User turns off auto-block normally (no manual intervention)
+
+**Flow:** Auto-block on → user turns off auto-block.
+
+**Current (no owner check):**
+1. Auto-block on → owner = `homeassistant-auto-block`, timer running.
+2. User turns off auto-block → `off` branch: release lock. Cancel timer.
+- **Result:** Lock released, block lifted immediately. **Correct.**
+
+**With owner check:**
+1. Same.
+2. User turns off auto-block → `off` branch: owner == `homeassistant-auto-block`? Yes → release. Cancel timer.
+- **Result:** Lock released, block lifted immediately. **Correct.**
+
+### Scenario E — User turns on auto-block while a manual lock exists
+
+**Flow:** Manual lock active (owner = `homeassistant-<user_id>`) → user turns on auto-block.
+
+**Current (no owner check):**
+1. Manual lock exists: owner = `homeassistant-<user_id>`, expires at T+1h.
+2. User turns on auto-block → `on` branch: release lock (wipes manual lock), create lock `homeassistant-auto-block`, start timer.
+- **Result:** Manual lock replaced by auto-block lock. The user's manual override is gone. **Arguably intentional** — the user explicitly turned on auto-block, so it should take effect. But the manual lock's remaining time is lost.
+
+**With owner check on the release (line 36):**
+1. Same.
+2. User turns on auto-block → `on` branch: owner == `homeassistant-auto-block`? **No** (it's `homeassistant-<user_id>`) → skip release. **But `create_lock` (POST) still replaces the lock.** Manual lock is still replaced.
+- **Result:** Same as current — manual lock replaced. The owner check on the pre-create release **does not help** because POST replaces regardless.
+
+**Implication:** The owner check on the `on` branch release is ineffective for preserving manual locks. To actually preserve manual locks when turning on auto-block, we would need to check the owner **before `create_lock`** and skip the entire create if a non-auto-block lock exists. This is a **separate design decision** (should auto-block override manual locks?) and not part of the C1 bug. The current behavior (auto-block overrides) appears intentional.
+
+**Recommendation for the `on` branch release:** Remove the pre-create `release_lock` entirely — it is redundant because `create_lock` (POST) replaces the existing lock. This eliminates a unnecessary DELETE call and simplifies the code. The `create_lock` will replace whatever lock exists, which is the current (intentional) behavior.
+
+### Scenario F — HA restart during various states
+
+The `ha_start` trigger fires the automation on every restart. The branch taken depends on `input_boolean.auto_block` state (which persists across restarts as an input_boolean).
+
+**F1: Restart with auto-block on, no manual intervention**
+
+**Current:**
+1. HA restarts → `ha_start` trigger → `on` branch: release lock, create new auto-block lock, start timer.
+2. Timer is reset (HA timers don't persist by default) — auto-block duration restarts from the selected duration, not the remaining time.
+- **Result:** Lock replaced with fresh auto-block lock. Duration reset. **Minor issue** — the auto-block period is extended. Pre-existing, not C1.
+
+**With owner check:** Same result — `create_lock` replaces regardless. The owner check on the pre-create release is ineffective (as in Scenario E).
+
+**F2: Restart with auto-block on, manual lock had replaced auto-block lock**
+
+**Current:**
+1. Before restart: owner = `homeassistant-<user_id>` (manual lock replaced auto-block).
+2. HA restarts → `on` branch: **unconditional release** wipes manual lock. Create new auto-block lock. Start timer.
+- **Result:** User's manual override destroyed on restart. **BUG (variant of C1).**
+
+**With owner check:**
+1. Same.
+2. `on` branch: owner == `homeassistant-auto-block`? No → skip release. But `create_lock` still replaces. Manual lock still replaced.
+- **Result:** Same as current. The owner check on the `on` branch release doesn't help (POST replaces). **Not fixed by owner check on release.** Would require checking before `create_lock` (separate design decision).
+
+**F3: Restart with auto-block off, manual lock exists**
+
+**Current:**
+1. Before restart: auto-block off, manual lock active (owner = `homeassistant-<user_id>`).
+2. HA restarts → `off` branch: **unconditional release** wipes manual lock. Cancel timer.
+- **Result:** **Every HA restart wipes ALL existing locks** (manual, gaming, etc.) when auto-block is off. **This is a broader bug than C1** — it affects gaming mode and any other lock consumer, not just manual overrides.
+
+**With owner check:**
+1. Same.
+2. `off` branch: owner == `homeassistant-auto-block`? **No** (it's `homeassistant-<user_id>`) → **skip release**. Cancel timer.
+- **Result:** Manual lock survives restart. **Correct.** This is a significant additional fix — the owner check prevents HA restart from wiping unrelated locks.
+
+**F4: Restart with auto-block off, stale auto-block lock exists**
+
+This can happen if auto-block was turned off but the lock wasn't released (e.g., due to a network error to the locking service).
+
+**With owner check:**
+1. Auto-block off, but lock owner = `homeassistant-auto-block` (stale).
+2. HA restarts → `off` branch: owner == `homeassistant-auto-block`? **Yes** → release. Cancel timer.
+- **Result:** Stale auto-block lock cleaned up. **Correct.**
+
+---
+
+## Edge Cases
+
+### 1. Sensor unavailable or stale (15s polling lag)
+
+`sensor.office_light_lock_status` polls every 15 seconds. There is a window where the sensor's reported owner lags behind the actual lock state.
+
+**Race condition:** User manually changes light → `manual_control` creates lock with `homeassistant-<user_id>`. Within the next 15 seconds, the auto-block timer expires. The sensor still shows owner = `homeassistant-auto-block` (not yet polled). The owner check passes, and the manual lock is released. **The owner check fails to protect in this window.**
+
+**Probability:** Low. The manual change and timer expiry must coincide within a 15-second window. The manual lock has a 1h duration; the timer has a 15m–2h duration. The overlap window is 15s out of the total auto-block period.
+
+**Sensor unavailable:** If the locking service is down, the sensor reports `unknown` and `state_attr(..., 'owner')` returns `None`. The owner check `None == 'homeassistant-auto-block'` is `false` → release skipped. This is **fail-safe** (don't release if unsure). The lock will expire naturally on the server when its duration ends. Acceptable.
+
+**Mitigation for the race condition:** See Alternative 1 (server-side owner-aware DELETE) below — it eliminates the race entirely by making the check atomic server-side.
+
+### 2. The ON branch — should it also check before releasing?
+
+The `on` branch (line 36) calls `release_lock` before `create_lock`. As analyzed in Scenario E, this release is **redundant** — `create_lock` (POST) replaces the existing lock regardless. The owner check on this release is ineffective for preserving manual locks because the subsequent POST replaces anyway.
+
+**Recommendation:** Remove the pre-create `release_lock` from the `on` branch entirely. It serves no purpose (POST replaces) and adds a unnecessary network call. This also eliminates the double-release concern for the `on` branch.
+
+If the design decision is later made to **not override** existing manual locks when turning on auto-block, that requires checking the owner **before `create_lock`** and skipping the create — a separate change.
+
+### 3. Interaction with gaming mode
+
+Gaming mode creates a 4h lock with owner `homeassistant-gaming-purple`.
+
+**Without owner check:** If gaming mode is active and the auto-block timer expires, the `timer_finished` branch unconditionally releases the gaming lock. **BUG** — same class as C1.
+
+**With owner check:** `timer_finished` branch checks owner == `homeassistant-auto-block`? No (it's `homeassistant-gaming-purple`) → skip release. Gaming lock survives. **Correct.**
+
+The gaming mode auto-off automation (`office_light_gaming_mode_purple_auto_off.yaml`) already uses an owner check — it only releases when owner == `homeassistant-gaming-purple`. This confirms the owner-check pattern is the established solution in this codebase.
+
+### 4. Double-release on timer expiry
+
+The `timer_finished` branch releases the lock and turns off `input_boolean.auto_block`. Turning off the input_boolean re-triggers the automation (`auto_block_toggle`), firing the `off` branch, which releases again.
+
+**Without owner check:** Second release hits an already-deleted lock → 404 error (harmless but noisy in logs).
+
+**With owner check:** Second release checks owner. If sensor is stale (still shows `homeassistant-auto-block`), passes check → DELETE on deleted lock → 404. If sensor is fresh (shows `unlocked`, owner None), fails check → skips. Either way, harmless.
+
+**Recommendation:** Add `continue_on-error: true` to the `release_lock` calls, or suppress the 404. Alternatively, restructure to avoid the double-release (e.g., don't turn off `input_boolean.auto_block` in the `timer_finished` branch — let the user see the timer expired and turn it off manually, or use a different mechanism). The double-release is a pre-existing issue, not introduced by the owner check.
+
+---
+
+## Alternative Solutions
+
+### Alternative 1 — Server-side owner-aware DELETE (most robust)
+
+**Change:** The locking service supports conditional DELETE: `DELETE /locks/{name}?owner={owner}` — only deletes if the current owner matches. Returns 409 Conflict if owner doesn't match.
+
+**HA change:** Add a new rest_command `release_lock_if_owner`:
+```yaml
+release_lock_if_owner:
+  url: "http://locking-service:3000/locks/{{ name }}?owner={{ owner }}"
+  method: DELETE
+```
+
+The auto-block automation calls `release_lock_if_owner` with `owner: homeassistant-auto-block` instead of `release_lock`.
+
+**Pros:**
+- **Atomic** — the owner check and delete happen in a single server-side operation. No race condition with the 15s polling lag.
+- No dependency on sensor freshness.
+- Clean separation of concerns — the locking service enforces ownership.
+
+**Cons:**
+- Requires changes to the external locking service (not in this repo).
+- All lock consumers would need to migrate to the owner-aware variant (or use both).
+- More work to implement and deploy.
+
+**Verdict:** Best long-term solution. Eliminates the race condition entirely. But requires cross-system coordination.
+
+### Alternative 2 — Track own lock state via a helper (fragile)
+
+**Change:** Add an `input_boolean.auto_block_owns_lock` helper. Set it to `on` when `create_lock` succeeds, set it to `off` when releasing. Check this helper before releasing instead of the sensor.
+
+**Pros:**
+- No dependency on sensor freshness — local state is instant.
+- No external service changes needed.
+
+**Cons:**
+- **Can get out of sync** — if the lock expires naturally on the server (duration elapsed), the helper still says "owns lock". The next release would skip, leaving a stale helper.
+- HA restart: `input_boolean` persists, but the lock state on the server may have changed during downtime. Helper says "owns" but server has no lock, or vice versa.
+- Adds another piece of state to maintain.
+
+**Verdict:** Fragile. Introduces a new sync problem. Not recommended.
+
+### Alternative 3 — Owner check via sensor (recommended immediate fix)
+
+**Change:** Add a template condition checking the lock owner before each `release_lock` call in the `timer_finished` and `off` branches. Remove the redundant `release_lock` from the `on` branch.
+
+```yaml
+# In timer_finished and off branches, before release_lock:
+- condition: template
+  value_template: >
+    {{ is_state('sensor.office_light_lock_status', 'locked')
+       and state_attr('sensor.office_light_lock_status', 'owner') == 'homeassistant-auto-block' }}
+```
+
+**Pros:**
+- **Follows the established pattern** — `office_light_gaming_mode_purple_auto_off.yaml` already does this.
+- Simple, minimal change — only touches `auto_block_control.yaml`.
+- No external service changes.
+- Fixes C1 for the `timer_finished` and `off` branches.
+- **Bonus:** Fixes the broader HA-restart-wipes-all-locks bug (Scenario F3).
+
+**Cons:**
+- **Race condition** — 15s polling lag means the sensor may show stale owner data. Small window where the check can fail to protect a manual lock.
+- Sensor unavailability causes release to be skipped (fail-safe, but the lock persists until natural expiry).
+
+**Verdict:** Best immediate fix. Consistent with existing codebase patterns. The race condition is low-probability and can be eliminated later with Alternative 1 if it proves to be a real problem.
+
+### Alternative 4 — Separate lock keys per consumer (architectural change)
+
+**Change:** Instead of one lock per resource (`office_light`), each consumer uses its own lock key (`office_light_auto_block`, `office_light_manual`, `office_light_gaming`). The block-status binary sensor checks if **any** of these locks exist.
+
+**Pros:**
+- **No collision possible** — each consumer manages its own lock independently.
+- No owner check needed — each consumer only touches its own lock.
+- Eliminates the entire class of collision bugs.
+
+**Cons:**
+- Requires locking service to support multiple locks per resource (or the block sensor queries multiple keys).
+- Changes to the block-status binary sensor (must check multiple lock keys).
+- Bigger refactor — touches all lock consumers.
+- The locking service's "one lock per key" model would need to change or be worked around.
+
+**Verdict:** Most architecturally clean, but a large refactor. Overkill for fixing C1. Could be a future improvement if lock collisions become a recurring problem across multiple consumers.
+
+---
+
+## Recommendation
+
+**Adopt Alternative 3 (owner check via sensor) as the immediate fix.**
+
+### Rationale
+
+1. **Consistency** — The gaming mode auto-off automation already uses this exact pattern. The fix brings auto-block control in line with established codebase conventions.
+2. **Minimal scope** — Only `auto_block_control.yaml` changes. No external service modifications, no new helpers, no refactoring of other consumers.
+3. **Fixes more than C1** — The owner check on the `off` branch also fixes the HA-restart-wipes-all-locks bug (Scenario F3), which is a broader issue affecting gaming mode and any other lock consumer.
+4. **Acceptable trade-off** — The 15s polling race condition is low-probability and fail-safe (worst case: a manual lock is released prematurely, same as the current bug, but only in a narrow window). Alternative 1 can eliminate this later if needed.
+
+### Specific changes to `auto_block_control.yaml`
+
+1. **`timer_finished` branch:** Add owner-check condition before `release_lock`. Only release if owner == `homeassistant-auto-block`.
+2. **`off` branch:** Add owner-check condition before `release_lock`. Only release if owner == `homeassistant-auto-block`.
+3. **`on` branch:** Remove the pre-create `release_lock` (line 36) — it is redundant because `create_lock` (POST) replaces the existing lock.
+4. **All `release_lock` calls:** Add `continue_on-error: true` to suppress 404 errors from the double-release on timer expiry.
+
+### What this does NOT fix (deferred)
+
+- **Scenario E / F2** (auto-block overriding manual locks): The `on` branch's `create_lock` POST replaces any existing lock. Preserving manual locks when turning on auto-block requires checking the owner before `create_lock` and skipping the create — a separate design decision about whether auto-block should override manual locks. Current behavior (override) appears intentional.
+- **Timer reset on HA restart (F1):** The timer restarts from the selected duration, not the remaining time. This is a pre-existing issue unrelated to C1.
+- **Race condition from 15s polling lag:** Eliminated by Alternative 1 (server-side owner-aware DELETE) if pursued later.
+
+### Future improvement path
+
+If the 15s polling race condition proves to be a real problem:
+1. Implement Alternative 1 (server-side owner-aware DELETE) in the locking service.
+2. Add `release_lock_if_owner` rest_command.
+3. Migrate all lock consumers to the owner-aware variant.
+4. The sensor-based owner check can then be removed (the server enforces ownership atomically).

--- a/docs/superpowers/specs/2026-07-29-auto-block-duration-duplication-design.md
+++ b/docs/superpowers/specs/2026-07-29-auto-block-duration-duplication-design.md
@@ -1,0 +1,192 @@
+---
+date: 2026-07-29
+topic: auto-block duration duplication (H1)
+status: proposed
+---
+
+# Auto-Block Duration Duplication — Design
+
+## 1. Problem
+
+`automation/auto_block_control.yaml` lines 38–113 expand one logical operation
+("start a lock + timer for the duration shown in `input_select.auto_block_duration`")
+into five near-identical `choose` branches (~75 lines of YAML). Only two values
+vary per branch: the lock `duration` (`15m`/`30m`/`45m`/`1h`/`2h`) and the
+`timer.start` `duration` (`HH:MM:SS`).
+
+Adding a new duration option today requires:
+
+1. editing `inputs/select/auto_block_duration.yaml` to add the option, **and**
+2. adding a sixth 11-line `choose` branch in the automation, **and**
+3. keeping the two duration formats in sync by hand.
+
+Three edits, two of them pure boilerplate, with no compile-time check that the
+formats match the option label.
+
+## 2. Constraints
+
+- **Dashboard consumer.** `ui-lovelace/00-test.yaml:170` renders
+  `input_select.auto_block_duration` via `custom:mushroom-select-card`. Any
+  approach that changes the helper's entity_id or domain forces a dashboard
+  edit and a `safe-refactoring` pass (entity rename → consumers).
+- **Curated option set.** The five options are non-uniform
+  (15, 30, 45, 60, 120 min). They are a deliberate UX choice, not a slider
+  range — `45 min` and `2 hours` are in, `75/90/105 min` are out.
+- **Two target formats.** `rest_command.create_lock` wants `15m`/`1h`/`2h`
+  (Go-style duration); `timer.start` wants `HH:MM:SS`.
+- **Codebase convention.** The same file already uses `condition: template`
+  for the lock-owner check (lines 22–24, 124–126), and the repo's other office
+  automations use Jinja2 templates. Templates are an established pattern here.
+- **Skill guidance.** `home-assistant-best-practices` says prefer native
+  conditions/helpers over templates — *but* explicitly endorses templates for
+  **dynamic service data** (`template-guidelines.md` §1), which is exactly
+  this case. The duplication is in service *data*, not in a condition.
+
+## 3. Approaches
+
+### Approach A — Template mapping (single dict + derived formats)
+
+Replace the five `choose` branches with two service calls whose `duration`
+fields are templates. Use **one** dict to map the select label → total minutes,
+then derive both target formats from that single source of truth.
+
+```yaml
+sequence:
+  - variables:
+      minutes: >
+        {% set m = {"15 min": 15, "30 min": 30, "45 min": 45,
+                     "1 hour": 60, "2 hours": 120} %}
+        {{ m.get(states('input_select.auto_block_duration'), 60) }}
+  - service: rest_command.create_lock
+    data:
+      name: office_light
+      owner: homeassistant-auto-block
+      duration: >
+        {{ (minutes // 60 ~ 'h') if minutes % 60 == 0 and minutes >= 60
+           else (minutes ~ 'm') }}
+  - service: timer.start
+    data:
+      duration: "{{ '%02d:%02d:00' | format(minutes // 60, minutes % 60) }}"
+    target:
+      entity_id: timer.auto_block
+```
+
+~12 lines replace ~75.
+
+### Approach B — `input_number` helper instead of select
+
+Replace `input_select.auto_block_duration` with `input_number.auto_block_minutes`
+(min 15, max 120, step 15). Derive both formats from the numeric state.
+
+- **Pro:** no dict; adding a duration needs no template edit (just widen the
+  range). Numeric state is always present → no "unknown option" failure mode.
+- **Con (decisive):** breaks the curated option set. Step 15 introduces
+  75/90/105 min which were deliberately excluded. To preserve the exact five
+  options you'd need step 15 *plus* a constraint, which `input_number` cannot
+  express — you'd be back to validating the value, i.e. reintroducing a
+  mapping. Non-uniform steps (15,15,15,60,60) aren't representable at all.
+- **Con:** entity_id migration → dashboard `mushroom-select-card` must become a
+  number/slider card; `safe-refactoring` workflow required. Higher blast
+  radius for a cosmetic refactor.
+- **Con:** the `1h`/`2h` vs `15m` formatting logic is fiddly and now runs for
+  *every* value, not just the curated five.
+
+### Approach C — One `input_boolean` per duration
+
+Rejected. Five booleans instead of one select multiplies state and does not
+reduce the `choose` branches — you still need a branch per boolean. Net
+duplication increase.
+
+### Approach D — Extract to a script
+
+Move the five branches into `script.auto_block_start` with a `field` for the
+duration label. The script body still needs the mapping, so this only
+*relocates* the duplication unless combined with A. Justified only if multiple
+automations call the same logic — here exactly one caller does. YAGNI.
+
+## 4. Evaluation Matrix
+
+| Criterion                         | A — Template (single dict) | B — input_number | C — booleans | D — script |
+|-----------------------------------|----------------------------|------------------|--------------|------------|
+| YAML LoC (automation)             | ~12 (−63)                  | ~12 (−63)        | ~+20         | ~12 here, +30 in script |
+| Edits to add a duration           | 2 (select + 1 dict entry)  | 1 (range)        | 3+           | 2–3        |
+| Load-time validation              | none (runtime template)    | none             | partial      | none       |
+| Preserves curated option set     | **yes**                    | no               | yes          | yes        |
+| Dashboard impact                  | none                       | card swap + rename | none       | none       |
+| Entity-id migration / blast radius| none                       | medium           | low          | none       |
+| Error handling on bad state       | dict `.get()` default      | n/a (always numeric) | n/a     | depends    |
+| Single source of truth for formats| **yes** (minutes → both)   | yes              | no           | if A inside |
+| Consistency with codebase         | matches existing templates | new pattern      | new pattern  | matches if templated |
+| Skill alignment                   | endorsed use (dynamic svc data) | neutral     | neutral      | neutral    |
+
+## 5. Recommendation
+
+**Approach A**, with the single-dict refinement (map label → minutes once,
+derive both target formats from `minutes`).
+
+### Rationale
+
+1. **Targets the actual duplication.** The boilerplate is in service *data*,
+   and templates for dynamic service data are the explicitly-approved use case
+   in `template-guidelines.md` §1. The skill's "prefer native" rule applies to
+   *conditions and helpers*, not to service-call arguments.
+2. **Single source of truth.** Mapping the label to `minutes` once — then
+   formatting for the lock and the timer from that one number — eliminates the
+   "two dicts to keep in sync" hazard that the raw Approach A in the review
+   prompt has. Adding `"3 hours": 180` is one dict entry; both formats update
+   automatically.
+3. **Zero blast radius.** No entity rename, no dashboard edit, no
+   `safe-refactoring` pass. The `mushroom-select-card` keeps working
+   unchanged. This is a pure automation-internal refactor.
+4. **Preserves the curated UX.** The five non-uniform options stay exactly as
+   designed — Approach B cannot represent them without reintroducing a mapping.
+5. **Consistent with the file.** The automation already uses
+   `condition: template` for the owner check two branches above; introducing a
+   template here is not a new pattern for the file.
+6. **Honest error handling.** `dict.get(state, 60)` falls back to the helper's
+   `initial` value (1 hour) if the select is `unknown`/`unavailable` or holds
+   a label not in the dict. The automation fails soft, not hard.
+
+### Why not B
+
+B's only real advantage (no dict, always-numeric state) is outweighed by the
+loss of the curated option set and the dashboard/entity migration cost. If the
+option set were uniform (e.g. 15,30,45,60,75,90,105,120) B would be attractive;
+for five hand-picked non-uniform values it is the wrong tool.
+
+### Why not D standalone
+
+D is a *container* decision, not a *duplication-elimination* decision. It only
+removes duplication when combined with A. With a single caller, the extra
+script indirection buys nothing. Revisit if a second consumer of this logic
+appears.
+
+## 6. Failure Modes & Mitigations
+
+| Failure                              | Behavior under A                          | Mitigation |
+|--------------------------------------|-------------------------------------------|------------|
+| Select state `unknown`/`unavailable` | `dict.get` returns default `60`           | Acceptable; matches helper `initial` |
+| Select label not in dict (drift)     | Same — default `60`                        | Add a log? `{{ log(..., 'warning') }}` optional |
+| `rest_command.create_lock` HTTP fail | `timer.start` still runs → timer without lock | Pre-existing; out of scope. Consider `continue_on_error: false` + ordering in a later task |
+| Template typo in format string       | Fails at runtime, not load                | Covered by `check_config` for syntax only; add an HA `test` run after edit |
+
+## 7. Implementation Plan (for Fixer)
+
+1. In `automation/auto_block_control.yaml`, replace the inner `choose:` block
+   (lines 38–113, the five duration branches) with the `variables` + two
+   service calls from §3.
+2. Keep the outer `choose` structure (the `auto_block_toggle on` branch) intact
+   — only its `sequence` changes.
+3. Do **not** touch `inputs/select/auto_block_duration.yaml` or
+   `ui-lovelace/00-test.yaml`.
+4. Validate: `ha config check` (or equivalent) for YAML/schema; then manually
+   toggle `input_boolean.auto_block` with each of the five select options and
+   confirm (a) the lock is created with the right `duration` and (b)
+   `timer.auto_block` shows the right countdown.
+5. Verify the `off`/`timer_finished` branches are unchanged.
+
+## 8. Out of Scope
+
+- Lock-service HTTP failure handling (pre-existing; track separately).
+- Generalizing to a script (Approach D) — defer until a second caller exists.
+- Migrating the select to `input_number` — rejected per §5.

--- a/inputs/boolean/auto_block.yaml
+++ b/inputs/boolean/auto_block.yaml
@@ -1,0 +1,5 @@
+---
+auto_block:
+  name: Auto Block
+  icon: mdi:shield-lock
+  initial: false

--- a/inputs/select/auto_block_duration.yaml
+++ b/inputs/select/auto_block_duration.yaml
@@ -1,0 +1,11 @@
+---
+auto_block_duration:
+  name: Auto Block Duration
+  icon: mdi:timer-outline
+  options:
+    - "15 min"
+    - "30 min"
+    - "45 min"
+    - "1 hour"
+    - "2 hours"
+  initial: "1 hour"

--- a/timers/auto_block.yaml
+++ b/timers/auto_block.yaml
@@ -1,0 +1,4 @@
+---
+auto_block:
+  name: Auto Block
+  duration: "01:00:00"

--- a/timers/auto_block.yaml
+++ b/timers/auto_block.yaml
@@ -2,3 +2,4 @@
 auto_block:
   name: Auto Block
   duration: "01:00:00"
+  restore: true

--- a/ui-lovelace/00-test.yaml
+++ b/ui-lovelace/00-test.yaml
@@ -153,6 +153,43 @@ sections:
                   - condition: state
                     entity: climate.office
                     state_not: "off"
+          - type: heading
+            heading_style: title
+            heading: Auto Block
+            icon: mdi:block-helper
+          - type: horizontal-stack
+            cards:
+              - type: tile
+                entity: input_boolean.auto_block
+                name: Auto Block
+                icon: mdi:shield-lock
+                color: red
+                vertical: false
+                show_entity_picture: false
+                features_position: bottom
+              - type: custom:mushroom-select-card
+                entity: input_select.auto_block_duration
+                fill_container: false
+                layout: horizontal
+                primary_info: name
+                secondary_info: none
+                name: Duration
+          - type: vertical-stack
+            cards:
+              - type: custom:timer-bar-card
+                entity: timer.auto_block
+                mushroom: null
+            visibility:
+              - condition: state
+                entity: timer.auto_block
+                state: active
+          - type: vertical-stack
+            cards:
+              - type: custom:mushroom-empty-card
+            visibility:
+              - condition: state
+                entity: timer.auto_block
+                state: idle
       - type: vertical-stack
         visibility:
           - condition: state


### PR DESCRIPTION
## Summary

Adds an **Auto Block** mode for the Office that prevents light automations from triggering while active.

### What was added

- `input_boolean.auto_block` — manual on/off toggle
- `timer.auto_block` — countdown timer (default 1h)
- `input_select.auto_block_duration` — selectable duration (15/30/45 min, 1/2 h)
- `automation/auto_block_control.yaml` — manages lock lifecycle via the locking service
- Dashboard card in the Office section of `00-test.yaml`

### How it works

Uses the existing locking service (`rest_command.create_lock`) to create a lock on `office_light` with owner `homeassistant-auto-block`. The existing `binary_sensor.office_light_automation_block_status` picks this up and blocks `office_light.yaml` — no changes needed to the light automation itself.

### Future

Easily extensible to other rooms by adding more lock names once per-room lock infrastructure exists.