### PR TITLE
bugfix(automation): guard lock owner against None user_id

### DIFF
--- a/automation/climate_bedroom_manual_control.yaml
+++ b/automation/climate_bedroom_manual_control.yaml
@@ -99,7 +99,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: hisense_ac_bedroom
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 1h
 
           # Log manual start
@@ -123,7 +123,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: hisense_ac_bedroom
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 1h
 
           # Log manual start

--- a/automation/climate_livingroom_manual_control.yaml
+++ b/automation/climate_livingroom_manual_control.yaml
@@ -99,7 +99,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: hisense_ac_livingroom
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 60m
 
           # Log manual start
@@ -123,7 +123,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: hisense_ac_livingroom
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 60m
 
           # Log manual start

--- a/automation/climate_office_manual_control.yaml
+++ b/automation/climate_office_manual_control.yaml
@@ -99,7 +99,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: hisense_ac_office
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 1h
 
           # Log manual start
@@ -123,7 +123,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: hisense_ac_office
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 1h
 
           # Log manual start

--- a/automation/garden_herb_irrigation_manual_control.yaml
+++ b/automation/garden_herb_irrigation_manual_control.yaml
@@ -96,7 +96,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: woox_irrigation_garden
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 15m
 
           # Increment daily counter
@@ -125,7 +125,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: woox_irrigation_garden
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 1h
 
           # Log manual stop

--- a/automation/garden_tomato_irrigation_manual_control.yaml
+++ b/automation/garden_tomato_irrigation_manual_control.yaml
@@ -96,7 +96,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: woox_irrigation_garden2
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 30m
 
           # Increment daily counter
@@ -125,7 +125,7 @@ actions:
           - service: rest_command.create_lock
             data:
               name: woox_irrigation_garden2
-              owner: "homeassistant-{{ trigger.to_state.context.user_id }}"
+              owner: "homeassistant-{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}"
               duration: 1h
 
           # Log manual stop

--- a/automation/office_light_manual_control.yaml
+++ b/automation/office_light_manual_control.yaml
@@ -152,14 +152,13 @@ actions:
   - service: rest_command.create_lock
     data:
       name: office_light
-      owner: >
-        {% if trigger.id == 'scene_change' and trigger.event.context.user_id is not none %}
-          homeassistant-{{ trigger.event.context.user_id }}
-        {% elif trigger.to_state.context.user_id is not none %}
-          homeassistant-{{ trigger.to_state.context.user_id }}
-        {% else %}
-          homeassistant-automation
-        {% endif %}
+      owner: >-
+        {%- if trigger.id == 'scene_change' -%}
+          {% set uid = trigger.event.context.user_id -%}
+        {%- else -%}
+          {% set uid = trigger.to_state.context.user_id -%}
+        {%- endif -%}
+        homeassistant-{{ 'automation' if uid is none else uid }}
       duration: 1h
 
   - service: system_log.write

--- a/automation/office_light_manual_control.yaml
+++ b/automation/office_light_manual_control.yaml
@@ -153,10 +153,12 @@ actions:
     data:
       name: office_light
       owner: >
-        {% if trigger.id == 'scene_change' %}
+        {% if trigger.id == 'scene_change' and trigger.event.context.user_id is not none %}
           homeassistant-{{ trigger.event.context.user_id }}
-        {% else %}
+        {% elif trigger.to_state.context.user_id is not none %}
           homeassistant-{{ trigger.to_state.context.user_id }}
+        {% else %}
+          homeassistant-automation
         {% endif %}
       duration: 1h
 


### PR DESCRIPTION
## Why this change

The manual-control automations created lock owners by templating `context.user_id` directly, e.g. `homeassistant-{{ trigger.to_state.context.user_id }}`. When a lock is acquired by something that has no logged-in user (a physical button, another automation, or a service call without a user context), `context.user_id` is `None`, so the owner rendered as `homeassistant-None`.

That string is not one of the reserved owners (`homeassistant-automation`, `homeassistant-gaming-purple`, `homeassistant-auto-block`), and the block-status sensors only exempt `homeassistant-automation`. So a `homeassistant-None` lock silently blocked the regular light/climate/irrigation automations for the full lock duration, even though no user had actually requested a manual override.

## What changed

Guard the `user_id` before building the owner:

- **`office_light_manual_control.yaml`**: use `is not none` checks; fall back to `homeassistant-automation`.
- **5 other manual-control automations** (climate office/livingroom/bedroom, garden herb/tomato): inline guard `{{ 'automation' if trigger.to_state.context.user_id is none else trigger.to_state.context.user_id }}`.

When no `user_id` is present, the event must originate from an automation or non-user source, so the lock is now correctly owned by `homeassistant-automation` and does not block the normal automation flows.