### PR TITLE
feat(groups): add rack motion sensor to motion basement group

### DIFF
--- a/groups/motion_basement.yaml
+++ b/groups/motion_basement.yaml
@@ -42,3 +42,4 @@ name: motion basement
 entities:
   - binary_sensor.mijia_motion_basement_stairs_down_occupancy
   - binary_sensor.mijia_motion_basement_stairs_up_occupancy
+  - binary_sensor.mijia_motion_rack_occupancy


### PR DESCRIPTION
Adds `binary_sensor.mijia_motion_rack_occupancy` to the `group.motion_basement` entity group so the basement motion group and its downstream automations react to rack motion.